### PR TITLE
Support OpenAI PDF file inputs

### DIFF
--- a/packages/shared/IpcChannel.ts
+++ b/packages/shared/IpcChannel.ts
@@ -118,6 +118,7 @@ export enum IpcChannel {
   File_Copy = 'file:copy',
   File_BinaryImage = 'file:binaryImage',
   File_Base64File = 'file:base64File',
+  File_GetPdfInfo = 'file:getPdfInfo',
   Fs_Read = 'fs:read',
 
   Export_Word = 'export:word',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -226,6 +226,7 @@ export function registerIpc(mainWindow: BrowserWindow, app: Electron.App) {
   ipcMain.handle(IpcChannel.File_Base64Image, fileManager.base64Image)
   ipcMain.handle(IpcChannel.File_SaveBase64Image, fileManager.saveBase64Image)
   ipcMain.handle(IpcChannel.File_Base64File, fileManager.base64File)
+  ipcMain.handle(IpcChannel.File_GetPdfInfo, fileManager.pdfPageCount)
   ipcMain.handle(IpcChannel.File_Download, fileManager.downloadFile)
   ipcMain.handle(IpcChannel.File_Copy, fileManager.copyFile)
   ipcMain.handle(IpcChannel.File_BinaryImage, fileManager.binaryImage)

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs'
 import { writeFileSync } from 'fs'
 import { readFile } from 'fs/promises'
 import officeParser from 'officeparser'
+import pdfParse from 'pdf-parse'
 import * as path from 'path'
 import { chdir } from 'process'
 import { v4 as uuidv4 } from 'uuid'
@@ -319,6 +320,13 @@ class FileStorage {
     const base64 = buffer.toString('base64')
     const mime = `application/${path.extname(filePath).slice(1)}`
     return { data: base64, mime }
+  }
+
+  public pdfPageCount = async (_: Electron.IpcMainInvokeEvent, id: string): Promise<number> => {
+    const filePath = path.join(this.storageDir, id)
+    const buffer = await fs.promises.readFile(filePath)
+    const data = await pdfParse(buffer)
+    return data.numpages
   }
 
   public binaryImage = async (_: Electron.IpcMainInvokeEvent, id: string): Promise<{ data: Buffer; mime: string }> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,7 @@ const api = {
     copy: (fileId: string, destPath: string) => ipcRenderer.invoke(IpcChannel.File_Copy, fileId, destPath),
     binaryImage: (fileId: string) => ipcRenderer.invoke(IpcChannel.File_BinaryImage, fileId),
     base64File: (fileId: string) => ipcRenderer.invoke(IpcChannel.File_Base64File, fileId),
+    pdfInfo: (fileId: string) => ipcRenderer.invoke(IpcChannel.File_GetPdfInfo, fileId),
     getPathForFile: (file: File) => webUtils.getPathForFile(file)
   },
   fs: {

--- a/src/renderer/src/aiCore/clients/openai/OpenAIResponseAPIClient.ts
+++ b/src/renderer/src/aiCore/clients/openai/OpenAIResponseAPIClient.ts
@@ -7,6 +7,7 @@ import {
 import { estimateTextTokens } from '@renderer/services/TokenService'
 import {
   FileTypes,
+  FileType,
   MCPCallToolResponse,
   MCPTool,
   MCPToolResponse,
@@ -36,6 +37,7 @@ import { findFileBlocks, findImageBlocks } from '@renderer/utils/messageUtils/fi
 import { buildSystemPrompt } from '@renderer/utils/prompt'
 import { isEmpty } from 'lodash'
 import OpenAI from 'openai'
+import { MB } from '@shared/config/constant'
 
 import { RequestTransformer, ResponseChunkTransformer } from '../types'
 import { OpenAIAPIClient } from './OpenAIApiClient'
@@ -90,6 +92,23 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
     return await sdk.responses.create(payload, options)
   }
 
+  private async handlePdfFile(file: FileType): Promise<OpenAI.Responses.ResponseInputFile | undefined> {
+    if (file.size > 32 * MB) return undefined
+    try {
+      const pageCount = await window.api.file.pdfInfo(file.id + file.ext)
+      if (pageCount > 100) return undefined
+    } catch {
+      return undefined
+    }
+
+    const { data } = await window.api.file.base64File(file.id + file.ext)
+    return {
+      type: 'input_file',
+      filename: file.origin_name,
+      file_data: `data:application/pdf;base64,${data}`
+    } as OpenAI.Responses.ResponseInputFile
+  }
+
   public async convertMessageToSdkParam(message: Message, model: Model): Promise<OpenAIResponseSdkMessageParam> {
     const isVision = isVisionModel(model)
     const content = await this.getMessageContent(message)
@@ -140,6 +159,14 @@ export class OpenAIResponseAPIClient extends OpenAIBaseClient<
     for (const fileBlock of fileBlocks) {
       const file = fileBlock.file
       if (!file) continue
+
+      if (isVision && file.ext === '.pdf') {
+        const pdfPart = await this.handlePdfFile(file)
+        if (pdfPart) {
+          parts.push(pdfPart)
+          continue
+        }
+      }
 
       if ([FileTypes.TEXT, FileTypes.DOCUMENT].includes(file.type)) {
         const fileContent = (await window.api.file.read(file.id + file.ext)).trim()


### PR DESCRIPTION
## Summary
- add new IPC channel and preload method for getting PDF info
- implement PDF page count retrieval in FileStorage
- add PDF base64 handling for OpenAI Response models

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684d660770748329a23d27dbd4329590